### PR TITLE
Update Paper API & use Adventure for chat messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This replaces legacy message strings with Adventure `Component`s. This should make the components smaller and cleaner in JSON form, and messages from CommandSpy should now be easier to programmatically parse.