### PR TITLE
refactor: use brigadier for command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <version>master</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.test.skip>true</maven.test.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/pw/kaboom/commandspy/command/PlayerOrUUIDArgumentType.java
+++ b/src/main/java/pw/kaboom/commandspy/command/PlayerOrUUIDArgumentType.java
@@ -1,0 +1,56 @@
+package pw.kaboom.commandspy.command;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.CustomArgumentType;
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.EntitySelectorArgumentResolver;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public final class PlayerOrUUIDArgumentType implements
+    CustomArgumentType<@NotNull Player, @NotNull EntitySelectorArgumentResolver> {
+
+    // We lie to clients and tell them we're an entity selector so that UUIDs don't show up as red.
+    @Override
+    public @NotNull ArgumentType<EntitySelectorArgumentResolver> getNativeType() {
+        return ArgumentTypes.entity();
+    }
+
+    @Override
+    public Player parse(final @NotNull StringReader reader) {
+        throw new IllegalStateException("method should never be called as we implement override");
+    }
+
+    @Override
+    public <S> Player parse(final @NotNull StringReader reader, final S source)
+        throws CommandSyntaxException {
+        if (!(source instanceof final CommandSourceStack stack))
+            throw new IllegalStateException("source was not a CommandSourceStack");
+
+        final int cursor = reader.getCursor();
+        final String string = reader.readString();
+
+        try {
+            final UUID uuid = UUID.fromString(string);
+            final Player player = Bukkit.getPlayer(uuid);
+
+            if (player != null) return player;
+        } catch (final IllegalArgumentException ignored) {
+        }
+
+        reader.setCursor(cursor);
+        return ArgumentTypes.player().parse(reader).resolve(stack).getFirst();
+    }
+
+    public static Player getPlayer(final CommandContext<CommandSourceStack> context,
+                                   final String name) {
+        return context.getArgument(name, Player.class);
+    }
+}

--- a/src/main/java/pw/kaboom/commandspy/command/StateArgumentType.java
+++ b/src/main/java/pw/kaboom/commandspy/command/StateArgumentType.java
@@ -1,0 +1,67 @@
+package pw.kaboom.commandspy.command;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.MessageComponentSerializer;
+import io.papermc.paper.command.brigadier.argument.CustomArgumentType;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+public final class StateArgumentType implements
+    CustomArgumentType.Converted<@NotNull Boolean, @NotNull String> {
+
+    private static final Collection<String> VALUES = Arrays.asList("on", "enable",
+        "off", "disable");
+
+    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
+        new DynamicCommandExceptionType(o ->
+            MessageComponentSerializer.message()
+                .serialize(Component.translatable("argument.enum.invalid")
+                    .arguments(Component.text(o.toString()))));
+
+    @Override
+    public @NotNull ArgumentType<String> getNativeType() {
+        return StringArgumentType.word();
+    }
+
+    @Override
+    public Boolean convert(final String s) throws CommandSyntaxException {
+        switch (s) {
+            case "on", "enable" -> {
+                return true;
+            }
+            case "off", "disable" -> {
+                return false;
+            }
+
+            default -> throw ERROR_INVALID_VALUE.create(s);
+        }
+    }
+
+    @Override
+    public <S> @NotNull CompletableFuture<Suggestions> listSuggestions(
+        final @NotNull CommandContext<S> context, final @NotNull SuggestionsBuilder builder) {
+        for (final String value: VALUES) {
+            if (!value.startsWith(builder.getRemainingLowerCase())) continue;
+
+            builder.suggest(value);
+        }
+
+        return builder.buildFuture();
+    }
+
+    public static boolean getState(final CommandContext<CommandSourceStack> context,
+                                   final String name) {
+        return context.getArgument(name, Boolean.class);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,13 +1,6 @@
 name: CommandSpy
 main: pw.kaboom.commandspy.Main
 description: Plugin that allows you to spy on players' commands.
-api-version: '1.20'
+api-version: '1.21'
 version: master
 folia-supported: true
-
-commands:
-   commandspy:
-      aliases: [ c, cs, cspy ]
-      description: Allows you to spy on players' commands
-      permission: commandspy.command
-      usage: '/<command> [player] [on|enable|off|disable]'


### PR DESCRIPTION
Makes the /commandspy command use Mojang's command system, for improved tab completion and highlighting. Also allows usage with selectors!

<img width="371" height="173" alt="image" src="https://github.com/user-attachments/assets/147da70e-210b-49d7-88aa-a76c499f3dd0" />
